### PR TITLE
ci: add conventional commit pr check

### DIFF
--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -1,0 +1,26 @@
+name: conventional-pr
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    types:
+      - opened
+      - edited
+      - synchronize
+jobs:
+  lint-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Release Bot Token
+        id: get-token
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.DS_RELEASE_BOT_ID }}
+          private_key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
Suggesting that we add https://github.com/marketplace/actions/conventional-pull-request. It has support for both validating PR Titles and commit messages.

Also reviewed:

* https://github.com/Namchee/conventional-pr - Probably more flexible and better community support, but I got overwhelmed will all the configuration
* https://github.com/marketplace/actions/conventional-pr-title - Only focused on titles, doesn't seem to address situations where commits get their message from the only commit in single-commit PRs.