### PR TITLE
fix(ingestor-api)!: store STAC item as string in DynamoDB

### DIFF
--- a/lib/ingestor-api/runtime/src/collection.py
+++ b/lib/ingestor-api/runtime/src/collection.py
@@ -3,9 +3,9 @@ import os
 from pypgstac.db import PgstacDB
 from pypgstac.load import Methods
 
+from .loader import Loader
 from .schemas import StacCollection
 from .utils import get_db_credentials
-from .loader import Loader
 
 
 def ingest(collection: StacCollection):

--- a/lib/ingestor-api/runtime/src/ingestor.py
+++ b/lib/ingestor-api/runtime/src/ingestor.py
@@ -23,7 +23,7 @@ def get_queued_ingestions(records: List["DynamodbRecord"]) -> Iterator[Ingestion
             k: deserializer.deserialize(v)
             for k, v in record["dynamodb"]["NewImage"].items()
         }
-        ingestion = Ingestion.construct(**parsed)
+        ingestion = Ingestion.parse_obj(parsed)
         if ingestion.status == Status.queued:
             yield ingestion
 

--- a/lib/ingestor-api/runtime/src/loader.py
+++ b/lib/ingestor-api/runtime/src/loader.py
@@ -27,7 +27,7 @@ class Loader(BaseLoader):
                     )
                 )
                 cur.execute(
-                    "SELECT dashboard.update_collection_default_summaries(%s)",
+                    "SELECT dashboard.update_default_summaries(%s)",
                     [collection_id],
                 )
                 logger.info("Updating bbox for collection: {}.".format(collection_id))

--- a/lib/ingestor-api/runtime/src/utils.py
+++ b/lib/ingestor-api/runtime/src/utils.py
@@ -8,8 +8,8 @@ import pydantic
 from pypgstac.db import PgstacDB
 from pypgstac.load import Methods
 
-from .schemas import Ingestion
 from .loader import Loader
+from .schemas import Ingestion
 
 
 class DbCreds(pydantic.BaseModel):

--- a/lib/ingestor-api/runtime/src/utils.py
+++ b/lib/ingestor-api/runtime/src/utils.py
@@ -42,10 +42,7 @@ def load_items(creds: DbCreds, ingestions: Sequence[Ingestion]):
     with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
         loader = Loader(db=db)
 
-        items = [
-            json.loads(orjson.dumps(i.item.dict()))
-            for i in ingestions
-        ]
+        items = [json.loads(orjson.dumps(i.item.dict())) for i in ingestions]
         loading_result = loader.load_items(
             file=items,
             # use insert_ignore to avoid overwritting existing items or upsert to replace

--- a/lib/ingestor-api/runtime/tests/conftest.py
+++ b/lib/ingestor-api/runtime/tests/conftest.py
@@ -20,6 +20,7 @@ def test_environ():
     os.environ["JWKS_URL"] = "https://test-jwks.url"
     os.environ["STAC_URL"] = "https://test-stac.url"
     os.environ["DATA_ACCESS_ROLE"] = "arn:aws:iam::123456789012:role/test-role"
+    os.environ["DB_SECRET_ARN"] = "testing"
 
 
 @pytest.fixture

--- a/lib/ingestor-api/runtime/tests/conftest.py
+++ b/lib/ingestor-api/runtime/tests/conftest.py
@@ -101,7 +101,10 @@ def example_stac_item():
                 ]
             ],
         },
-        "properties": {"datetime": "2020-12-11T22:38:32.125000Z"},
+        "properties": {
+            "datetime": "2020-12-11T22:38:32.125000Z",
+            "eo:cloud_cover": 1,
+        },
         "collection": "simple-collection",
         "links": [
             {

--- a/lib/ingestor-api/runtime/tests/conftest.py
+++ b/lib/ingestor-api/runtime/tests/conftest.py
@@ -129,13 +129,13 @@ def example_stac_item():
         ],
         "assets": {
             "visual": {
-                "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",  # noqa
+                "href": "https://TEST_API.com/open-cogs/stac-examples/20201211_223832_CS2.tif",  # noqa
                 "type": "image/tiff; application=geotiff; profile=cloud-optimized",
                 "title": "3-Band Visual",
                 "roles": ["visual"],
             },
             "thumbnail": {
-                "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",  # noqa
+                "href": "https://TEST_API.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",  # noqa
                 "title": "Thumbnail",
                 "type": "image/jpeg",
                 "roles": ["thumbnail"],
@@ -248,10 +248,7 @@ def client_authenticated(app):
     """
     from src.dependencies import get_username
 
-    def skip_auth():
-        pass
-
-    app.dependency_overrides[get_username] = skip_auth
+    app.dependency_overrides[get_username] = lambda: 'test_user'
     return TestClient(app)
 
 

--- a/lib/ingestor-api/runtime/tests/test_ingestor.py
+++ b/lib/ingestor-api/runtime/tests/test_ingestor.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+import pytest
+
+
+@pytest.fixture()
+def dynamodb_stream_event():
+    return {
+        "Records": None
+    }
+
+
+@pytest.fixture()
+def get_queued_ingestions(example_ingestion):
+    with patch("src.ingestor.get_queued_ingestions",
+               return_value=iter([example_ingestion]), autospec=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def get_db_credentials():
+    with patch("src.ingestor.get_db_credentials",
+               return_value="", autospec=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def load_items():
+    with patch("src.ingestor.load_items", return_value=0, autospec=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def get_table(mock_table):
+    with patch("src.ingestor.get_table", return_value=mock_table, autospec=True) as m:
+        yield m
+
+
+def test_handler(
+    monkeypatch,
+    test_environ,
+    dynamodb_stream_event,
+    example_ingestion,
+    get_queued_ingestions,
+    get_db_credentials,
+    load_items,
+    get_table,
+    mock_table,
+):
+    import src.ingestor as ingestor
+    ingestor.handler(dynamodb_stream_event, {})
+    load_items.assert_called_once_with(
+        creds="",
+        ingestions=list([example_ingestion]),
+    )
+    response = mock_table.get_item(Key={
+        "created_by": example_ingestion.created_by,
+        "id": example_ingestion.id
+    })
+    assert response["Item"]["status"] == "succeeded"

--- a/lib/ingestor-api/runtime/tests/test_ingestor.py
+++ b/lib/ingestor-api/runtime/tests/test_ingestor.py
@@ -1,25 +1,26 @@
 from unittest.mock import patch
+
 import pytest
 
 
 @pytest.fixture()
 def dynamodb_stream_event():
-    return {
-        "Records": None
-    }
+    return {"Records": None}
 
 
 @pytest.fixture()
 def get_queued_ingestions(example_ingestion):
-    with patch("src.ingestor.get_queued_ingestions",
-               return_value=iter([example_ingestion]), autospec=True) as m:
+    with patch(
+        "src.ingestor.get_queued_ingestions",
+        return_value=iter([example_ingestion]),
+        autospec=True,
+    ) as m:
         yield m
 
 
 @pytest.fixture()
 def get_db_credentials():
-    with patch("src.ingestor.get_db_credentials",
-               return_value="", autospec=True) as m:
+    with patch("src.ingestor.get_db_credentials", return_value="", autospec=True) as m:
         yield m
 
 
@@ -47,13 +48,13 @@ def test_handler(
     mock_table,
 ):
     import src.ingestor as ingestor
+
     ingestor.handler(dynamodb_stream_event, {})
     load_items.assert_called_once_with(
         creds="",
         ingestions=list([example_ingestion]),
     )
-    response = mock_table.get_item(Key={
-        "created_by": example_ingestion.created_by,
-        "id": example_ingestion.id
-    })
+    response = mock_table.get_item(
+        Key={"created_by": example_ingestion.created_by, "id": example_ingestion.id}
+    )
     assert response["Item"]["status"] == "succeeded"

--- a/lib/ingestor-api/runtime/tests/test_registration.py
+++ b/lib/ingestor-api/runtime/tests/test_registration.py
@@ -2,14 +2,132 @@ import base64
 import json
 from datetime import timedelta
 from typing import TYPE_CHECKING, List
+from unittest.mock import call, patch
 
+from fastapi.encoders import jsonable_encoder
 import pytest
+
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
     from src import schemas, services
 
 ingestion_endpoint = "/ingestions"
+
+
+@pytest.fixture()
+def collection_exists():
+    with patch("src.validators.collection_exists", return_value=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def collection_missing():
+    def bad_collection(collection_id: str):
+        raise ValueError("MOCKED MISSING COLLECTION ERROR")
+
+    with patch("src.validators.collection_exists", side_effect=bad_collection) as m:
+        yield m
+
+
+@pytest.fixture()
+def asset_exists():
+    with patch("src.validators.url_is_accessible", return_value=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def asset_missing():
+    def bad_asset_url(href: str):
+        raise ValueError("MOCKED INACCESSIBLE URL ERROR")
+
+    with patch("src.validators.url_is_accessible", side_effect=bad_asset_url) as m:
+        yield m
+
+
+class TestCreate:
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        api_client: "TestClient",
+        mock_table: "services.Table",
+        example_ingestion: "schemas.Ingestion",
+    ):
+        from src import services
+
+        self.api_client = api_client
+        self.mock_table = mock_table
+        self.db = services.Database(self.mock_table)
+        self.example_ingestion = example_ingestion
+
+    def test_unauthenticated_create(self):
+        response = self.api_client.post(
+            ingestion_endpoint,
+            json=jsonable_encoder(self.example_ingestion.item),
+        )
+
+        assert response.status_code == 403
+
+    def test_create(self, client_authenticated, collection_exists, asset_exists):
+        response = self.api_client.post(
+            ingestion_endpoint,
+            json=jsonable_encoder(self.example_ingestion.item),
+        )
+
+        assert response.status_code == 201
+        assert collection_exists.called_once_with(
+            self.example_ingestion.item.collection
+        )
+
+        stored_data = self.db.fetch_many(status="queued")["items"]
+        assert len(stored_data) == 1
+        assert json.loads(stored_data[0].json(by_alias=True)) == response.json()
+
+    def test_validates_missing_collection(
+        self, client_authenticated, collection_missing, asset_exists
+    ):
+        response = self.api_client.post(
+            ingestion_endpoint,
+            json=jsonable_encoder(self.example_ingestion.item),
+        )
+
+        collection_missing.assert_called_once_with(
+            collection_id=self.example_ingestion.item.collection
+        )
+        assert response.status_code == 422, "should get validation error"
+        assert (
+            len(self.db.fetch_many(status="queued")["items"]) == 0
+        ), "data should not be stored in DB"
+
+    def test_validates_missing_assets(
+        self, client_authenticated, collection_exists, asset_missing
+    ):
+        response = self.api_client.post(
+            ingestion_endpoint,
+            json=jsonable_encoder(self.example_ingestion.item),
+        )
+
+        collection_exists.assert_called_once_with(
+            collection_id=self.example_ingestion.item.collection
+        )
+        asset_missing.assert_has_calls(
+            [
+                call(href=asset.href)
+                for asset in self.example_ingestion.item.assets.values()
+            ],
+            any_order=True,
+        )
+        assert response.status_code == 422, "should get validation error"
+        for asset_type in self.example_ingestion.item.assets.keys():
+            assert any(
+                [
+                    err["loc"] == ["body", "assets", asset_type, "href"]
+                    for err in response.json()["detail"]
+                ]
+            ), "should reference asset type in validation error response"
+        assert (
+            len(self.db.fetch_many(status="queued")["items"]) == 0
+        ), "data should not be stored in DB"
 
 
 class TestList:
@@ -36,8 +154,7 @@ class TestList:
 
     def test_simple_lookup(self):
         self.mock_table.put_item(Item=self.example_ingestion.dynamodb_dict())
-        ingestion = self.example_ingestion.dynamodb_dict()
-        ingestion["item"] = json.loads(ingestion["item"])
+        ingestion = jsonable_encoder(self.example_ingestion)
         response = self.api_client.get(ingestion_endpoint)
         assert response.status_code == 200
         assert response.json() == {
@@ -58,13 +175,7 @@ class TestList:
         response = self.api_client.get(ingestion_endpoint, params={"limit": limit})
         assert response.status_code == 200
         assert json.loads(base64.b64decode(response.json()["next"])) == expected_next
-        ingestions = []
-        for ingestion in example_ingestions[:limit]:
-            item = ingestion.dynamodb_dict()
-            item["item"] = json.loads(item["item"])
-            ingestions.append(item)
-
-        assert response.json()["items"] == ingestions
+        assert response.json()["items"] == jsonable_encoder(example_ingestions[:limit])
 
     @pytest.mark.skip(reason="Test is currently broken")
     def test_get_next_page(self):

--- a/lib/ingestor-api/runtime/tests/test_utils.py
+++ b/lib/ingestor-api/runtime/tests/test_utils.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 
 import orjson
 import pytest
-
 from pypgstac.load import Methods
 from src.utils import DbCreds
 
@@ -23,21 +22,15 @@ def pgstacdb():
 
 @pytest.fixture()
 def dbcreds():
-    dbcreds = DbCreds(
-        username="",
-        password="",
-        host="",
-        port=1,
-        dbname="",
-        engine=""
-    )
+    dbcreds = DbCreds(username="", password="", host="", port=1, dbname="", engine="")
     return dbcreds
 
 
 def test_load_items(loader, pgstacdb, example_ingestion, dbcreds):
     import src.utils as utils
+
     utils.load_items(dbcreds, list([example_ingestion]))
     loader.return_value.load_items.assert_called_once_with(
         file=[json.loads(orjson.dumps(example_ingestion.item.dict()))],
-        insert_mode=Methods.upsert
+        insert_mode=Methods.upsert,
     )

--- a/lib/ingestor-api/runtime/tests/test_utils.py
+++ b/lib/ingestor-api/runtime/tests/test_utils.py
@@ -1,9 +1,8 @@
-import json
 from unittest.mock import Mock, patch
 
-import orjson
 import pytest
 from pypgstac.load import Methods
+from fastapi.encoders import jsonable_encoder
 from src.utils import DbCreds
 
 
@@ -31,6 +30,6 @@ def test_load_items(loader, pgstacdb, example_ingestion, dbcreds):
 
     utils.load_items(dbcreds, list([example_ingestion]))
     loader.return_value.load_items.assert_called_once_with(
-        file=[json.loads(orjson.dumps(example_ingestion.item.dict()))],
+        file=jsonable_encoder([example_ingestion.item]),
         insert_mode=Methods.upsert,
     )

--- a/lib/ingestor-api/runtime/tests/test_utils.py
+++ b/lib/ingestor-api/runtime/tests/test_utils.py
@@ -1,0 +1,43 @@
+import json
+from unittest.mock import Mock, patch
+
+import orjson
+import pytest
+
+from pypgstac.load import Methods
+from src.utils import DbCreds
+
+
+@pytest.fixture()
+def loader():
+    with patch("src.utils.Loader", autospec=True) as m:
+        yield m
+
+
+@pytest.fixture()
+def pgstacdb():
+    with patch("src.utils.PgstacDB", autospec=True) as m:
+        m.return_value.__enter__.return_value = Mock()
+        yield m
+
+
+@pytest.fixture()
+def dbcreds():
+    dbcreds = DbCreds(
+        username="",
+        password="",
+        host="",
+        port=1,
+        dbname="",
+        engine=""
+    )
+    return dbcreds
+
+
+def test_load_items(loader, pgstacdb, example_ingestion, dbcreds):
+    import src.utils as utils
+    utils.load_items(dbcreds, list([example_ingestion]))
+    loader.return_value.load_items.assert_called_once_with(
+        file=[json.loads(orjson.dumps(example_ingestion.item.dict()))],
+        insert_mode=Methods.upsert
+    )


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/NASA-IMPACT/veda-data-pipelines/issues/313.  The PR updates the ingestor code to serialize the STAC `item` property of the `ingestion` as a string prior to storing it in DynamoDB.  Additionally, it updates the code used to deserialize `ingestions` queried from the DynamoDB table and load them into `pgstac` and adds unit test coverage for some of the `ingestor` code paths (which previously had no coverage).