### PR TITLE
refactor: remove VEDA logic

### DIFF
--- a/lib/bootstrapper/runtime/handler.py
+++ b/lib/bootstrapper/runtime/handler.py
@@ -133,6 +133,7 @@ def register_extensions(cursor) -> None:
     """Add PostGIS extension."""
     cursor.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS postgis;"))
 
+
 def handler(event, context):
     """Lambda Handler."""
     print(f"Handling {event}")

--- a/lib/bootstrapper/runtime/handler.py
+++ b/lib/bootstrapper/runtime/handler.py
@@ -133,78 +133,6 @@ def register_extensions(cursor) -> None:
     """Add PostGIS extension."""
     cursor.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS postgis;"))
 
-
-def create_dashboard_schema(cursor, username: str) -> None:
-    """Create custom schema for dashboard-specific functions."""
-    cursor.execute(
-        sql.SQL(
-            "CREATE SCHEMA IF NOT EXISTS dashboard;"
-            "GRANT ALL ON SCHEMA dashboard TO {username};"
-            "ALTER ROLE {username} SET SEARCH_PATH TO dashboard, pgstac, public;"
-        ).format(username=sql.Identifier(username))
-    )
-
-
-def create_update_default_summaries_function(cursor) -> None:
-    """Create function to update collection summary metadata about default item assets."""
-
-    update_default_summary_sql = """
-    CREATE OR REPLACE FUNCTION dashboard.update_default_summaries(_collection_id text) RETURNS VOID AS $$
-    WITH coll_item_cte AS (
-        SELECT jsonb_build_object(
-            'summaries',
-            jsonb_build_object(
-                'datetime', (
-                    CASE
-                    WHEN (collections."content"->>'dashboard:is_periodic')::boolean
-                    THEN (to_jsonb(array[
-                        to_char(min(datetime) at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-                        to_char(max(datetime) at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')]))
-                    ELSE jsonb_agg(distinct to_char(datetime at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'))
-                    END
-                ),
-                'cog_default', (
-                    CASE
-                    WHEN collections."content"->'item_assets' ? 'cog_default'
-                    THEN jsonb_build_object(
-                        'min', min((items."content"->'assets'->'cog_default'->'raster:bands'-> 0 ->'statistics'->>'minimum')::float),
-                        'max', max((items."content"->'assets'->'cog_default'->'raster:bands'-> 0 ->'statistics'->>'maximum')::float)
-                        )
-                    ELSE NULL
-                    END
-                )
-            )
-        ) summaries,
-        collections.id coll_id
-        FROM items
-        JOIN collections on items.collection = collections.id
-        WHERE collections.id = _collection_id
-        GROUP BY collections."content" , collections.id
-    )
-    UPDATE collections SET "content" = "content" || coll_item_cte.summaries
-    FROM coll_item_cte
-    WHERE collections.id = coll_item_cte.coll_id;
-    $$ LANGUAGE SQL SET SEARCH_PATH TO dashboard, pgstac, public;
-    """
-
-    cursor.execute(sql.SQL(update_default_summary_sql))
-
-
-def create_update_all_default_summaries_function(cursor) -> None:
-    """Create function to update default summaries for all collections with required properties"""
-
-    update_all_default_summaries_sql = """
-    CREATE OR REPLACE FUNCTION dashboard.update_all_default_summaries() RETURNS VOID AS $$
-    SELECT
-        update_default_summaries(id)
-    FROM collections
-    WHERE collections."content" ?| array['item_assets', 'dashboard:is_periodic'];
-    $$ LANGUAGE SQL SET SEARCH_PATH TO dashboard, pgstac, public;
-    """
-
-    cursor.execute(sql.SQL(update_all_default_summaries_sql))
-
-
 def handler(event, context):
     """Lambda Handler."""
     print(f"Handling {event}")
@@ -296,16 +224,6 @@ def handler(event, context):
                     "CREATE INDEX IF NOT EXISTS searches_mosaic ON searches ((true)) WHERE metadata->>'type'='mosaic';"
                 )
             )
-
-        # As admin, create custom dashboard schema and functions and grant privileges to bootstrapped user
-        with psycopg.connect(stac_db_conninfo, autocommit=True) as conn:
-            with conn.cursor() as cur:
-                print("Creating dashboard schema...")
-                create_dashboard_schema(cursor=cur, username=user_params["username"])
-
-                print("Creating update_default_summaries functions...")
-                create_update_default_summaries_function(cursor=cur)
-                create_update_all_default_summaries_function(cursor=cur)
 
     except Exception as e:
         print(f"Unable to bootstrap database with exception={e}")

--- a/lib/ingestor-api/runtime/src/loader.py
+++ b/lib/ingestor-api/runtime/src/loader.py
@@ -14,31 +14,6 @@ class Loader(BaseLoader):
         self.check_version()
         self.conn = self.db.connect()
 
-    def update_collection_summaries(self, collection_id: str) -> None:
-        """Update collection-level summaries for a single collection.
-        This includes dashboard summaries (i.e. datetime and cog_default) as well as
-        STAC-conformant bbox and temporal extent."""
-
-        with self.conn.cursor() as cur:
-            with self.conn.transaction():
-                logger.info(
-                    "Updating dashboard summaries for collection: {}.".format(
-                        collection_id
-                    )
-                )
-                cur.execute(
-                    "SELECT dashboard.update_default_summaries(%s)",
-                    [collection_id],
-                )
-                logger.info("Updating bbox for collection: {}.".format(collection_id))
-                cur.execute("SELECT pgstac.collection_bbox(%s)", [collection_id])
-                logger.info(
-                    "Updating temporal extent for collection: {}.".format(collection_id)
-                )
-                cur.execute(
-                    "SELECT pgstac.collection_temporal_extent(%s)", [collection_id]
-                )
-
     def delete_collection(self, collection_id: str) -> None:
         with self.conn.cursor() as cur:
             with self.conn.transaction():

--- a/lib/ingestor-api/runtime/src/utils.py
+++ b/lib/ingestor-api/runtime/src/utils.py
@@ -48,5 +48,5 @@ def load_items(creds: DbCreds, ingestions: Sequence[Ingestion]):
             # use insert_ignore to avoid overwritting existing items or upsert to replace
             insert_mode=Methods.upsert,
         )
-        
+
         return loading_result

--- a/lib/ingestor-api/runtime/src/utils.py
+++ b/lib/ingestor-api/runtime/src/utils.py
@@ -48,10 +48,5 @@ def load_items(creds: DbCreds, ingestions: Sequence[Ingestion]):
             # use insert_ignore to avoid overwritting existing items or upsert to replace
             insert_mode=Methods.upsert,
         )
-
-        # Trigger update on summaries and extents
-        collections = set([item["collection"] for item in items])
-        for collection in collections:
-            loader.update_collection_summaries(collection)
-
+        
         return loading_result


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/developmentseed/cdk-pgstac/issues/28. 

- removed the [VEDA schema and functions ingested here](https://github.com/developmentseed/cdk-pgstac/blob/4ef537c7ef5f3f7b8fd9b2cccd5e49633dd3aa3e/lib/bootstrapper/runtime/handler.py#L304), create_dashboard_schema, create_update_default_summaries_function, create_update_all_default_summaries_function.

- removed the usage of `update_default_summaries`, where we were updating the collection summary while inserting new items.
