### PR TITLE
fix(bootstraper): fix version inconsistencies and #19 regressions

### DIFF
--- a/lib/bootstrapper/index.ts
+++ b/lib/bootstrapper/index.ts
@@ -17,7 +17,7 @@ function hasVpc(
   return (instance as aws_rds.DatabaseInstance).vpc !== undefined;
 }
 
-const DEFAULT_PGSTAC_VERSION = "0.6.8";
+const DEFAULT_PGSTAC_VERSION = "0.6.13";
 
 /**
  * Bootstraps a database instance, installing pgSTAC onto the database.

--- a/lib/ingestor-api/runtime/src/collection.py
+++ b/lib/ingestor-api/runtime/src/collection.py
@@ -18,6 +18,7 @@ def ingest(collection: StacCollection):
         creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             loader = Loader(db=db)
+            collection = [collection.to_dict()] # pypgstac wants either a string or an Iterable of dicts. 
             loader.load_collections(file=collection, insert_mode=Methods.upsert)
     except Exception as e:
         print(f"Encountered failure loading collection into pgSTAC: {e}")

--- a/lib/ingestor-api/runtime/src/collection.py
+++ b/lib/ingestor-api/runtime/src/collection.py
@@ -18,7 +18,9 @@ def ingest(collection: StacCollection):
         creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             loader = Loader(db=db)
-            collection = [collection.to_dict()] # pypgstac wants either a string or an Iterable of dicts. 
+            collection = [
+                collection.to_dict()
+            ]  # pypgstac wants either a string or an Iterable of dicts.
             loader.load_collections(file=collection, insert_mode=Methods.upsert)
     except Exception as e:
         print(f"Encountered failure loading collection into pgSTAC: {e}")

--- a/lib/ingestor-api/runtime/src/collection.py
+++ b/lib/ingestor-api/runtime/src/collection.py
@@ -18,7 +18,7 @@ def ingest(collection: StacCollection):
         creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             loader = Loader(db=db)
-            loader.load_collection(file=collection, insert_mode=Methods.upsert)
+            loader.load_collections(file=collection, insert_mode=Methods.upsert)
     except Exception as e:
         print(f"Encountered failure loading collection into pgSTAC: {e}")
 

--- a/lib/ingestor-api/runtime/tests/conftest.py
+++ b/lib/ingestor-api/runtime/tests/conftest.py
@@ -248,7 +248,7 @@ def client_authenticated(app):
     """
     from src.dependencies import get_username
 
-    app.dependency_overrides[get_username] = lambda: 'test_user'
+    app.dependency_overrides[get_username] = lambda: "test_user"
     return TestClient(app)
 
 
@@ -256,20 +256,7 @@ def client_authenticated(app):
 def stac_collection(example_stac_collection):
     from src import schemas
 
-    return schemas.StacCollection(
-        id=example_stac_collection["id"],
-        type=example_stac_collection["type"],
-        stac_extensions=example_stac_collection["stac_extensions"],
-        item_assets=example_stac_collection["item_assets"],
-        stac_version=example_stac_collection["stac_version"],
-        description=example_stac_collection["description"],
-        title=example_stac_collection["title"],
-        providers=example_stac_collection["providers"],
-        extent=example_stac_collection["extent"],
-        license=example_stac_collection["license"],
-        summaries=example_stac_collection["summaries"],
-        links=example_stac_collection["links"],
-    )
+    return schemas.StacCollection(**example_stac_collection)
 
 
 @pytest.fixture

--- a/lib/ingestor-api/runtime/tests/test_collection.py
+++ b/lib/ingestor-api/runtime/tests/test_collection.py
@@ -6,10 +6,12 @@ from src.schemas import StacCollection
 import src.collection as collection
 import os
 
+
 @pytest.fixture()
 def loader():
     with patch("src.collection.Loader", autospec=True) as m:
         yield m
+
 
 @pytest.fixture()
 def pgstacdb():
@@ -17,12 +19,18 @@ def pgstacdb():
         m.return_value.__enter__.return_value = Mock()
         yield m
 
+
 def test_load_collections(example_stac_collection, loader, pgstacdb):
     example_stac_collection = StacCollection(**example_stac_collection)
-    with patch('src.collection.get_db_credentials', return_value=DbCreds(username="", password="", host="", port=1, dbname="", engine="")):
-        os.environ['DB_SECRET_ARN'] = ''
+    with patch(
+        "src.collection.get_db_credentials",
+        return_value=DbCreds(
+            username="", password="", host="", port=1, dbname="", engine=""
+        ),
+    ):
+        os.environ["DB_SECRET_ARN"] = ""
         collection.ingest(example_stac_collection)
-    
+
     loader.return_value.load_collections.assert_called_once_with(
         file=[example_stac_collection.to_dict()],
         insert_mode=Methods.upsert,

--- a/lib/ingestor-api/runtime/tests/test_collection.py
+++ b/lib/ingestor-api/runtime/tests/test_collection.py
@@ -20,8 +20,7 @@ def pgstacdb():
         yield m
 
 
-def test_load_collections(example_stac_collection, loader, pgstacdb):
-    example_stac_collection = StacCollection(**example_stac_collection)
+def test_load_collections(stac_collection, loader, pgstacdb):
     with patch(
         "src.collection.get_db_credentials",
         return_value=DbCreds(
@@ -29,9 +28,9 @@ def test_load_collections(example_stac_collection, loader, pgstacdb):
         ),
     ):
         os.environ["DB_SECRET_ARN"] = ""
-        collection.ingest(example_stac_collection)
+        collection.ingest(stac_collection)
 
     loader.return_value.load_collections.assert_called_once_with(
-        file=[example_stac_collection.to_dict()],
+        file=[stac_collection.to_dict()],
         insert_mode=Methods.upsert,
     )

--- a/lib/ingestor-api/runtime/tests/test_collection.py
+++ b/lib/ingestor-api/runtime/tests/test_collection.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, patch
 import pytest
 from pypgstac.load import Methods
 from src.utils import DbCreds
-from src.schemas import StacCollection
 import src.collection as collection
 import os
 

--- a/lib/ingestor-api/runtime/tests/test_collection.py
+++ b/lib/ingestor-api/runtime/tests/test_collection.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock, patch
+import pytest
+from pypgstac.load import Methods
+from src.utils import DbCreds
+from src.schemas import StacCollection
+import src.collection as collection
+import os
+
+@pytest.fixture()
+def loader():
+    with patch("src.collection.Loader", autospec=True) as m:
+        yield m
+
+@pytest.fixture()
+def pgstacdb():
+    with patch("src.collection.PgstacDB", autospec=True) as m:
+        m.return_value.__enter__.return_value = Mock()
+        yield m
+
+def test_load_collections(example_stac_collection, loader, pgstacdb):
+    example_stac_collection = StacCollection(**example_stac_collection)
+    with patch('src.collection.get_db_credentials', return_value=DbCreds(username="", password="", host="", port=1, dbname="", engine="")):
+        os.environ['DB_SECRET_ARN'] = ''
+        collection.ingest(example_stac_collection)
+    
+    loader.return_value.load_collections.assert_called_once_with(
+        file=[example_stac_collection.to_dict()],
+        insert_mode=Methods.upsert,
+    )


### PR DESCRIPTION
- [x] fix inconsistent `pypgstac` versions in bootstrapper and stac-ingestor
- [x] fix regression introduced by #19 : `pypgstac.load` does not have a `load_collection` but a `load_collections` method. I am unsure about my fix : it looks like `load_collections` excepts a json containing a list of collection metadata. How is it going to behave if we have a single collection in it ? 
- [x] make sure the value passed to the `file` parameter of the `pypgstac` collection loader is a `list` of `dict`. 