### PR TITLE
feat(ingestor-api): expose ingestor handler role

### DIFF
--- a/lib/ingestor-api/index.ts
+++ b/lib/ingestor-api/index.ts
@@ -16,7 +16,7 @@ import { Construct } from "constructs";
 
 export class StacIngestor extends Construct {
   table: dynamodb.Table;
-  public readonly handler_role: iam.Role;
+  public handlerRole: iam.Role;
 
   constructor(scope: Construct, id: string, props: StacIngestorProps) {
     super(scope, id);
@@ -32,7 +32,7 @@ export class StacIngestor extends Construct {
       ...props.apiEnv,
     };
 
-    this.handler_role = new iam.Role(this, "execution-role", {
+    this.handlerRole = new iam.Role(this, "execution-role", {
       description:
         "Role used by STAC Ingestor. Manually defined so that we can choose a name that is supported by the data access roles trust policy",
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -118,7 +118,7 @@ export class StacIngestor extends Construct {
       vpc: props.dbVpc,
       vpcSubnets: props.subnetSelection,
       allowPublicSubnet: true,
-      role: this.handler_role,
+      role: this.handlerRole,
       memorySize: 2048,
     });
 

--- a/lib/ingestor-api/index.ts
+++ b/lib/ingestor-api/index.ts
@@ -16,6 +16,7 @@ import { Construct } from "constructs";
 
 export class StacIngestor extends Construct {
   table: dynamodb.Table;
+  public readonly handler_role: iam.Role;
 
   constructor(scope: Construct, id: string, props: StacIngestorProps) {
     super(scope, id);
@@ -31,6 +32,20 @@ export class StacIngestor extends Construct {
       ...props.apiEnv,
     };
 
+    this.handler_role = new iam.Role(this, "execution-role", {
+      description:
+        "Role used by STAC Ingestor. Manually defined so that we can choose a name that is supported by the data access roles trust policy",
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaBasicExecutionRole",
+        ),
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaVPCAccessExecutionRole",
+        ),
+      ],
+    });
+    
     const handler = this.buildApiLambda({
       table: this.table,
       env,
@@ -91,23 +106,9 @@ export class StacIngestor extends Construct {
     dbSecret: secretsmanager.ISecret;
     dbVpc: ec2.IVpc;
     dbSecurityGroup: ec2.ISecurityGroup;
-    subnetSelection: ec2.SubnetSelection;
+    subnetSelection: ec2.SubnetSelection
   }): PythonFunction {
-    const handler_role = new iam.Role(this, "execution-role", {
-      description:
-        "Role used by STAC Ingestor. Manually defined so that we can choose a name that is supported by the data access roles trust policy",
-      roleName: `stac-ingestion-api-${props.stage}`,
-      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AWSLambdaBasicExecutionRole",
-        ),
-        iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AWSLambdaVPCAccessExecutionRole",
-        ),
-      ],
-    });
-
+    
     const handler = new PythonFunction(this, "api-handler", {
       entry: `${__dirname}/runtime`,
       index: "src/handler.py",
@@ -117,7 +118,7 @@ export class StacIngestor extends Construct {
       vpc: props.dbVpc,
       vpcSubnets: props.subnetSelection,
       allowPublicSubnet: true,
-      role: handler_role,
+      role: this.handler_role,
       memorySize: 2048,
     });
 
@@ -132,7 +133,6 @@ export class StacIngestor extends Construct {
     );
 
     props.table.grantReadWriteData(handler);
-    props.dataAccessRole.grantAssumeRole(handler_role);
 
     return handler;
   }


### PR DESCRIPTION
* added a new public read only handler_role property to the StacIngestor construct. As a consequence, I had to move the handler_role creation to the constructor.

* the role name is now automatically generated by AWS. We were manually defining it before so that users could import the role with its name (e.g to modify the data access role policy), but because we're now directly using the role object (i.e an `iam.Role` object) from the property, the name does not matter. Since manually defining a role name is restrictive (see the documentation of the parameter on the API reference), I think it's better to let AWS choose it. 

BREAKING CHANGE: the role name is automatically generated by AWS and thus users can not use the name that was specified before, but should directly interact with the new property (`iam.Role`) that we are adding.

https://github.com/developmentseed/aws-asdi-pgstac/issues/20, https://github.com/developmentseed/cdk-pgstac/pull/38