### PR TITLE
fix(bootstrapper): bootstrapper should use httpx

### DIFF
--- a/lib/bootstrapper/runtime/Dockerfile
+++ b/lib/bootstrapper/runtime/Dockerfile
@@ -5,7 +5,7 @@ RUN echo "Using PGSTAC Version ${PGSTAC_VERSION}"
 
 WORKDIR /tmp
 
-RUN pip install requests psycopg[binary,pool] pypgstac==${PGSTAC_VERSION} -t /asset
+RUN pip install httpx psycopg[binary,pool] pypgstac==${PGSTAC_VERSION} -t /asset
 
 COPY runtime/handler.py /asset/handler.py
 

--- a/lib/bootstrapper/runtime/handler.py
+++ b/lib/bootstrapper/runtime/handler.py
@@ -61,7 +61,7 @@ def send(
         response = httpx.put(responseUrl, data=json_responseBody, headers=headers)
         print("Status code: " + response.reason)
     except Exception as e:
-        print("send(..) failed executing requests.put(..): " + str(e))
+        print("send(..) failed executing httpx.put(..): " + str(e))
 
 
 def get_secret(secret_name):

--- a/lib/bootstrapper/runtime/handler.py
+++ b/lib/bootstrapper/runtime/handler.py
@@ -6,7 +6,7 @@ import json
 
 import boto3
 import psycopg
-import requests
+import httpx
 from psycopg import sql
 from psycopg.conninfo import make_conninfo
 from pypgstac.db import PgstacDB
@@ -58,7 +58,7 @@ def send(
     headers = {"content-type": "", "content-length": str(len(json_responseBody))}
 
     try:
-        response = requests.put(responseUrl, data=json_responseBody, headers=headers)
+        response = httpx.put(responseUrl, data=json_responseBody, headers=headers)
         print("Status code: " + response.reason)
     except Exception as e:
         print("send(..) failed executing requests.put(..): " + str(e))


### PR DESCRIPTION
Addresses https://github.com/developmentseed/cdk-pgstac/issues/44 by using httpx instead of requests in bootstrapper.

I tested this with cdk-pgstac deployment I am using for EODC (see https://github.com/developmentseed/tile-benchmarking/tree/feat/deploy-pgstac) where I made these changes in the installed node_module for cdk-pgstac and deployed.