### PR TITLE
fix(ingestor-api): add stack name to ingestor-api apigateway export name

### DIFF
--- a/lib/ingestor-api/index.ts
+++ b/lib/ingestor-api/index.ts
@@ -201,7 +201,7 @@ export class StacIngestor extends Construct {
 
         cloudWatchRole: true,
         deployOptions: { stageName: props.stage },
-        endpointExportName: `ingestor-api-${props.stage}`,
+        endpointExportName: `${Stack.of(this)}-ingestor-api`,
 
         endpointConfiguration: props.endpointConfiguration,
         policy: props.policy,


### PR DESCRIPTION
The Cloud Formation export name of the ingestor api `api gateway endpoint` was "ingestor-api-{stage}". In the case of multiple deployments of these constructs in the same AWS account, stage and region, which can happen for experimental reasons, this creates problems (For each AWS account, an export name must be unique within a region https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html).

This PR adds the name of the stack as a prefix of the export name, like it's done for (most?) all the other exports in this library. 