### PR TITLE
feat!: bump stac-fastapi-pgstac dependency

### DIFF
--- a/lib/stac-api/runtime/requirements.txt
+++ b/lib/stac-api/runtime/requirements.txt
@@ -1,2 +1,2 @@
-stac-fastapi-pgstac[awslambda]>=5.0,<5.1
+stac-fastapi-pgstac[awslambda]>=6.0,<6.1
 starlette-cramjam>=0.4,<0.5


### PR DESCRIPTION
This gets us a lot of stuff, including the ability to enable transaction extension via envvar, disabling transaction extensions by default, and better CORS configuration. For a full list: https://github.com/stac-utils/stac-fastapi-pgstac/releases/tag/6.0.0.

This is breaking on the **pgstac** envvar renames, so I made this commit breaking via conventional commits.

## :warning: Checklist if your PR is changing anything else than documentation

- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction): https://github.com/developmentseed/eoapi-cdk/actions/runs/16832687195/job/47684167342
