### PR TITLE
fix: refactor Lambda constructs to only build custom image if provided

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,3 +2,30 @@ import { aws_lambda as lambda } from "aws-cdk-lib";
 
 export type CustomLambdaFunctionProps = lambda.FunctionProps | any;
 export const DEFAULT_PGSTAC_VERSION = "0.9.5";
+
+/**
+ * Resolves Lambda code by using custom user code if provided,
+ * otherwise builds a Docker image with the specified arguments.
+ *
+ * @param userCode - User-provided custom code (optional)
+ * @param dockerBuildPath - Path for Docker build
+ * @param dockerBuildOptions - Options for Docker build
+ * @returns Lambda code configuration
+ */
+export function resolveLambdaCode(
+  userCode?: lambda.Code,
+  dockerBuildPath?: string,
+  dockerBuildOptions?: lambda.DockerBuildAssetOptions
+): lambda.Code {
+  if (userCode) {
+    return userCode;
+  }
+
+  if (!dockerBuildPath || !dockerBuildOptions) {
+    throw new Error(
+      "dockerBuildPath and dockerBuildOptions are required when no custom code is provided"
+    );
+  }
+
+  return lambda.Code.fromDockerBuild(dockerBuildPath, dockerBuildOptions);
+}


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction): https://github.com/developmentseed/eoapi-cdk/actions/runs/18018581123

## Merge request description
For multiple reasons we do not want deployments to have to build the default image when a custom runtime is provided - this refactors the way custom runtimes get provided to the lambda.Function constructs so that the default runtime docker build never gets executed if a custom runtime is provided via `lambdaFunctionOptions`.

resolves #87
