### PR TITLE
feat: only re-deploy db bootstrap if code or config parameters change

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -47,7 +47,7 @@ function hasVpc(
  */
 function computeLambdaCodeHash(
   basePath: string,
-  buildArgs: { [key: string]: string }
+  buildArgs: { [key: string]: string },
 ): string {
   const hash = crypto.createHash("sha256");
 
@@ -64,7 +64,7 @@ function computeLambdaCodeHash(
   // Hash build arguments in sorted order for consistency
   const sortedArgs = Object.keys(buildArgs)
     .sort()
-    .map(key => `${key}=${buildArgs[key]}`)
+    .map((key) => `${key}=${buildArgs[key]}`)
     .join(",");
   hash.update(`buildArgs:${sortedArgs}`);
 


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) https://github.com/developmentseed/eoapi-cdk/actions/runs/21529286129/job/62040875149

## Merge request description

This PR replaces the timestamp-based CustomResource property with a hash calculated from the bootstrap lambda code. It only works if the default bootstrap runtime is used. Users with custom bootstrap runtimes can force the bootstrap process to re-deploy with a new flag `forceBootstrap`.