### PR TITLE
fix: only trigger the pgbouncer healthcheck when the database changes

### DIFF
--- a/lib/database/PgBouncer.ts
+++ b/lib/database/PgBouncer.ts
@@ -60,6 +60,12 @@ export interface PgBouncerProps {
    * EC2 instance options
    */
   instanceProps?: Partial<ec2.InstanceProps>;
+
+  /**
+   * Optional reference to the database bootstrapper CustomResource.
+   * When provided, the health check will re-trigger if the database setup changes.
+   */
+  databaseBootstrapper?: CustomResource;
 }
 
 export class PgBouncer extends Construct {
@@ -255,8 +261,10 @@ export class PgBouncer extends Construct {
       serviceToken: healthCheckFunction.functionArn,
       properties: {
         InstanceId: this.instance.instanceId,
-        // Add timestamp to force re-execution on stack updates
-        Timestamp: new Date().toISOString(),
+        // Reference the database bootstrapper to re-trigger on database changes
+        ...(props.databaseBootstrapper && {
+          DatabaseBootstrapperRef: props.databaseBootstrapper.ref,
+        }),
       },
     });
 

--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -276,6 +276,7 @@ export class PgStacDatabase extends Construct {
           reservePoolSize: 5,
           reservePoolTimeout: 5,
         },
+        databaseBootstrapper: bootstrapper,
       });
 
       this._pgBouncerServer.node.addDependency(bootstrapper);


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [ ] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction) https://github.com/developmentseed/eoapi-cdk/actions/runs/21756409824/job/62767792738

## Merge request description
Only retrigger the pgbouncer healthcheck if the pgbouncer instance is re-created or if the pgstac database bootstrap process was triggered.

resolves #228