### PR TITLE
chore: add runtime directories to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "uv"
+    directories:
+      - "/lib/ingestor-api/runtime"
+      - "/lib/stac-api/runtime"
+      - "/lib/stac-auth-proxy/runtime"
+      - "/lib/stac-loader/runtime"
+      - "/lib/stactools-item-generator/runtime"
+      - "/lib/tipg-api/runtime"
+      - "/lib/titiler-pgstac-api/runtime"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-runtime-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/uv.lock
+++ b/uv.lock
@@ -904,7 +904,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3" },
     { name = "httpx", specifier = ">=0.24" },
     { name = "moto", extras = ["dynamodb", "ssm"], specifier = ">=4.0,<5.0" },
     { name = "pytest", specifier = ">=7.0" },


### PR DESCRIPTION
The runtimes are frozen with uv.lock files, we should be patching those.