### PR TITLE
chore: skip pypgstac in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
       - "/lib/titiler-pgstac-api/runtime"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "pypgstac"
     open-pull-requests-limit: 10
     groups:
       python-runtime-dependencies:


### PR DESCRIPTION
## Merge request description
We don't pin pypgstac in pyproject.toml files because the version is configured at deploy time.