### PR TITLE
chore: update stac-auth-proxy to v1.1.1

### DIFF
--- a/lib/stac-auth-proxy/runtime/pyproject.toml
+++ b/lib/stac-auth-proxy/runtime/pyproject.toml
@@ -5,7 +5,7 @@ description = "stac-auth-proxy-api runtime"
 requires-python = ">=3.12"
 dependencies = [
     "mangum==0.19",
-    "stac-auth-proxy>=0.6,<1",
+    "stac-auth-proxy>=1.1.1",
 ]
 
 [build-system]

--- a/lib/stac-auth-proxy/runtime/requirements.txt
+++ b/lib/stac-auth-proxy/runtime/requirements.txt
@@ -1,1 +1,1 @@
-stac-auth-proxy>=0.6,<1
+stac-auth-proxy>=1.1.1


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction): https://github.com/developmentseed/eoapi-cdk/actions/runs/26525312283

## Merge request description

Floor'd **stac-auth-proxy** version to force a pick up of https://github.com/developmentseed/stac-auth-proxy/pull/170. @hrodmn I see you have https://github.com/developmentseed/eoapi-cdk/pull/262 but thought I'd open this one just in case we just want to do **stac-auth-proxy**?