### PR TITLE
fix: install npm latest for distribute-js

### DIFF
--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -49,5 +49,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Update npm to the latest version
+        run: npm install -g npm@latest
+
+      - name: Check npm version
+        run: npm -v
+
       - name: Publish to npm
         run: npm publish dist/* --provenance --access public


### PR DESCRIPTION
## Merge request description
- distribute-js erroring out: https://github.com/developmentseed/eoapi-cdk/actions/runs/31039623057/job/92420669998#step:4:122
- reintroduce npm install latest
