### PR TITLE
fix: increase memory of stac-browser BucketDeployment

### DIFF
--- a/integration_tests/cdk/app.py
+++ b/integration_tests/cdk/app.py
@@ -13,6 +13,7 @@ from constructs import Construct
 from eoapi_cdk import (
     PgStacApiLambda,
     PgStacDatabase,
+    StacBrowser,
     StacIngestor,
     StacLoader,
     StactoolsItemGenerator,
@@ -216,6 +217,14 @@ class pgStacInfraStack(Stack):
         )
 
         stac_bucket.grant_read(self.stac_loader.lambda_function)
+
+        StacBrowser(
+            self,
+            "stac-browser",
+            stac_catalog_url=stac_api.url,
+            github_repo_tag="v5.0.0",
+            website_index_document="index.html",
+        )
 
 
 app = App()

--- a/integration_tests/cdk/app.py
+++ b/integration_tests/cdk/app.py
@@ -222,7 +222,8 @@ class pgStacInfraStack(Stack):
             self,
             "stac-browser",
             stac_catalog_url=stac_api.url,
-            github_repo_tag="v5.0.0",
+            github_repo_tag=app_config.stac_browser_version,
+            auto_delete_objects=True,
             website_index_document="index.html",
         )
 

--- a/integration_tests/cdk/config.py
+++ b/integration_tests/cdk/config.py
@@ -26,6 +26,10 @@ class AppConfig(BaseSettings):
         description="Allocated storage for the database", default=5
     )
 
+    stac_browser_version: str = pydantic.Field(
+        description="Tagged version of the STAC Browser to use", default="v5.0.0"
+    )
+
     @pydantic.field_validator("tags")
     def default_tags(cls, v, info: FieldValidationInfo):
         return v or {"project_id": info.data["project_id"], "stage": info.data["stage"]}

--- a/lib/stac-browser/index.ts
+++ b/lib/stac-browser/index.ts
@@ -25,6 +25,7 @@ export class StacBrowser extends Construct {
             this.bucket = new s3.Bucket(this, 'Bucket', {
                 accessControl: s3.BucketAccessControl.PRIVATE,
                 removalPolicy: RemovalPolicy.DESTROY,
+                autoDeleteObjects: props.autoDeleteObjects,
                 websiteIndexDocument: props.websiteIndexDocument
             })
         }
@@ -204,6 +205,17 @@ export interface StacBrowserProps {
      * @default - No index document.
      */
     readonly websiteIndexDocument?: string;
+
+    /**
+     * Whether to automatically delete all objects in the managed bucket before
+     * bucket deletion. Useful for ephemeral stacks and test environments.
+     *
+     * Ignored when `bucketArn` is provided because imported buckets are not
+     * managed by this construct.
+     *
+     * @default - false
+     */
+    readonly autoDeleteObjects?: boolean;
 
     /**
      * Location in the filesystem where to compile the browser code.

--- a/lib/stac-browser/index.ts
+++ b/lib/stac-browser/index.ts
@@ -1,4 +1,4 @@
-import { Stack, aws_s3 as s3, aws_s3_deployment as s3_deployment} from "aws-cdk-lib";
+import { Size, Stack, aws_s3 as s3, aws_s3_deployment as s3_deployment} from "aws-cdk-lib";
 import { RemovalPolicy, CfnOutput } from "aws-cdk-lib";
 import { PolicyStatement, ServicePrincipal, Effect } from "aws-cdk-lib/aws-iam";
 
@@ -48,7 +48,9 @@ export class StacBrowser extends Construct {
         // add the compiled code to the bucket as a bucket deployment
         this.bucketDeployment = new s3_deployment.BucketDeployment(this, 'BucketDeployment', {
             destinationBucket: this.bucket,
-            sources: [s3_deployment.Source.asset(buildPath)]
+            sources: [s3_deployment.Source.asset(buildPath)],
+            memoryLimit: 1024,
+            ephemeralStorageSize: Size.mebibytes(1024),
           });
 
         new CfnOutput(this, "bucket-name", {


### PR DESCRIPTION
## :warning: Checklist if your PR is changing anything else than documentation
- [x] Posted the link to a successful manually triggered deployment workflow (successful including the resources destruction)

## Merge request description
- Increase the memory limits of the stac-browser BucketDeployment. Initial deployment shows a timeout with near max memory usage
  >Duration: 900000.00 ms Billed Duration: 900000 ms Memory Size: 128 MB Max Memory Used: 126 MB Status: timeout
- Added stac-browser to integration build test
- Added auto_delete_objects for stac-browser s3 bucket
